### PR TITLE
Added fix for ios 14 to use UIImageView if it is not an animated image

### DIFF
--- a/Libraries/Image/RCTUIImageViewAnimated.m
+++ b/Libraries/Image/RCTUIImageViewAnimated.m
@@ -269,6 +269,8 @@ static NSUInteger RCTDeviceFreeMemory() {
   if (_currentFrame) {
     layer.contentsScale = self.animatedImageScale;
     layer.contents = (__bridge id)_currentFrame.CGImage;
+  } else {
+    [super displayLayer:layer];
   }
 }
 


### PR DESCRIPTION
- Fix for issue with loading images in iOS 14 

This pulls in the change which is included in [react-native 0.63.2](https://github.com/facebook/react-native/commit/123423c2a9258c9af25ca9bffe1f10c42a176bf3)

